### PR TITLE
Added work around for spurious extra socket read wait events that int…

### DIFF
--- a/game/platforms/SDL/gameSDL.cpp
+++ b/game/platforms/SDL/gameSDL.cpp
@@ -4846,6 +4846,15 @@ int sendToSocket( int inHandle, unsigned char *inData, int inDataLength ) {
         screen->getSocketEventTypeAndSize( inHandle, 
                                            &nextType, &nextNumBodyBytes );
         
+        while( nextType == 2 && nextNumBodyBytes == 0 ) {
+            // skip over any lingering waiting-for-read events
+            // sometimes there are extra in recording that aren't needed
+            // on playback for some reason
+            screen->getSocketEventTypeAndSize( inHandle, 
+                                           &nextType, &nextNumBodyBytes );
+            }
+        
+            
         if( nextType == 0 ) {
             return nextNumBodyBytes;
             }


### PR DESCRIPTION
…erfere with socket send results on playback.  Not sure why this work-around is needed, but it allowed previously broken recordings to play back.